### PR TITLE
[BUG] /harvest-entrypoint chown on limited fileset

### DIFF
--- a/harvest/harvest-entrypoint.sh
+++ b/harvest/harvest-entrypoint.sh
@@ -6,7 +6,8 @@ function init_local_user() {
     uid=${LOCAL_USER_ID:-9001}
     useradd --create-home --shell /bin/bash --uid ${uid} ucd.process
     export HOME=/home/ucd.process
-    chown -R ucd.process:ucd.process /home/ucd.process
+    chown ucd.process:ucd.process /home/ucd.process /home/ucd.process/*
+    chown -R ucd.process:ucd.process /home/ucd.process/configuration  /home/ucd.process/databases /home/ucd.process/logs /home/ucd.process/system  /home/ucd.process/system_files  /home/ucd.process/templates
   fi
 }
 


### PR DESCRIPTION
The previous chown command would take a long time if there was a big cache, so this limits to a small subset