### PR TITLE
[BUG] add default sorting and site-farm esp.

### DIFF
--- a/services/base-service/models/expert/model.js
+++ b/services/base-service/models/expert/model.js
@@ -184,17 +184,29 @@ class ExpertModel extends BaseModel {
     */
     let defaults = {
       'is-visible' : true,
-      expert : { 
+      expert : {
         include : true,
         size : -1
       },
-      grants : { 
+      grants : {
         include : false,
         size : -1
       },
-      works : { 
+      works : {
         include : false,
-        size : -1
+        size : -1,
+        includeMisformatted : false,
+        sort : [
+          {
+              "field": "issued",
+              "sort": "desc",
+              "type": "year"
+            },
+            {
+              "field": "title",
+              "sort": "asc",
+              "type": "string"
+            } ]
       }
     }
     options = {...defaults, ...options};

--- a/services/base-service/models/sitefarm/api.js
+++ b/services/base-service/models/sitefarm/api.js
@@ -27,12 +27,40 @@ function siteFarmFormat(req, res, next) {
         'is-visible' : true,
         expert : { include : true },
         grants : {
-          include : false
+          include : false,
+          exclude: [
+            "totalAwardAmount"
+          ],
+          includeMisformattedd: false,
+          sort: [
+            {
+              "field": "dateTimeInterval.end.dateTime",
+              "sort": "desc",
+              "type": "date"
+            },
+            {
+              "field": "name",
+              "sort": "asc",
+              "type": "string"
+            }
+          ]
         },
         works : {
           include :true,
           page : 1,
-          size : 5
+          size : 5,
+          includeMisformatted : false,
+          sort : [
+            {
+              "field": "issued",
+              "sort": "desc",
+              "type": "year"
+            },
+            {
+              "field": "title",
+              "sort": "asc",
+              "type": "string"
+            } ]
         }
       } );
 


### PR DESCRIPTION
The site farm API was updated to use our standard  experts `model.subselect()`  function.  However, site farm didn't include any sorting information in it's call, and that's  not part of the defaults in the model.   This PR adds sensical sorting defaults to the subselect function, and explicitly sets them in sitefarm's api as well, in case those change. 

